### PR TITLE
Remove scope in client sign in

### DIFF
--- a/src/lib/client/auth.ts
+++ b/src/lib/client/auth.ts
@@ -7,7 +7,6 @@ const authClient = createAuthClient({
 export const signInWithGoogle = () =>
   authClient.signIn.social({ 
     provider: "google",
-    scopes: ["https://www.googleapis.com/auth/gmail.send"], 
   });
 
 export const signOut = authClient.signOut;


### PR DESCRIPTION
# Issue
- Blocked sign in by client due to the scope

# Solution
- Remove the scope in auth